### PR TITLE
Refactoring and presence subscription

### DIFF
--- a/whatsapi.js
+++ b/whatsapi.js
@@ -277,7 +277,7 @@ WhatsApi.prototype.requestLastSeen = function(who) {
 WhatsApi.prototype.sendPresenceSubscription = function(who) {
 	var attributes = {
 		type : 'subscribe',
-		name : this.createJID(who)
+		to : this.createJID(who)
 	};
 	var node = new protocol.Node('presence', attributes);
 	
@@ -287,7 +287,7 @@ WhatsApi.prototype.sendPresenceSubscription = function(who) {
 WhatsApi.prototype.sendPresenceUnsubscription = function(who) {
 	var attributes = {
 		type : 'unsubscribe',
-		name : this.createJID(who)
+		to : this.createJID(who)
 	};
 	var node = new protocol.Node('presence', attributes);
 	

--- a/whatsapi.js
+++ b/whatsapi.js
@@ -274,6 +274,26 @@ WhatsApi.prototype.requestLastSeen = function(who) {
 	this.sendNode(new protocol.Node('iq', attributes, [queryNode]));
 };
 
+WhatsApi.prototype.sendPresenceSubscription = function(who) {
+	var attributes = {
+		type : 'subscribe',
+		name : this.createJID(who)
+	};
+	var node = new protocol.Node('presence', attributes);
+	
+	this.sendNode(node);
+};
+
+WhatsApi.prototype.sendPresenceUnsubscription = function(who) {
+	var attributes = {
+		type : 'unsubscribe',
+		name : this.createJID(who)
+	};
+	var node = new protocol.Node('presence', attributes);
+	
+	this.sendNode(node);
+};
+
 WhatsApi.prototype.requestContactsSync = function(msisdnList) {
 	if(!this.contactsSync) {
 		this.initContactsSync();

--- a/whatsapi.js
+++ b/whatsapi.js
@@ -124,7 +124,11 @@ WhatsApi.prototype.sendIsOnline = function() {
 	this.sendNode(new protocol.Node('presence', attributes));
 };
 
-WhatsApi.prototype.sendofflineStatus = function() {
+WhatsApi.prototype.sendIsOffline = function() {
+	this.sendOfflineStatus();
+};
+
+WhatsApi.prototype.sendOfflineStatus = function() {
 	var attributes = {
 		type : 'unavailable',
 		name : this.config.username


### PR DESCRIPTION
1) Fixed camelCase in `sendOfflineStatus` and added alias `sendIsOffline`
for consistency with `sendIsOnline`

2) New `sendPresenceSubscription` and `sendPresenceUnsubscription`
functions.

Calling `sendIsOnline` is required for the subscription to work.
Subscription won’t work if `sendOfflineStatus` is called after
subscribing.

The `presence.available` event is already there and can be used.