### PR TITLE
fixed image resizing, group changes

### DIFF
--- a/whatsapi.js
+++ b/whatsapi.js
@@ -2169,7 +2169,7 @@ WhatsApi.prototype.createImageThumbnail = function(srcPath, callback) {
 					}
 					
 					this.quality(80);
-					this.resize(200, 200);
+					this.resize(96, 96);
 					this.getBuffer(mime.lookup(srcPath), function(buffer) {
 						callback(false, buffer.toString('base64'));
 					});
@@ -2196,9 +2196,9 @@ WhatsApi.prototype.createImageThumbnail = function(srcPath, callback) {
 			gm(srcPath)
 				.options(options)
 				.quality(80)
-				.resize(200, 200, '^')
+				.resize(96, 96, '^')
 				.gravity('Center')
-				.crop(200, 200)
+				.crop(96, 96)
 				.toBuffer(function(err, buffer) {
 					if (err) callback(err);
 					callback(false, buffer.toString('base64'));


### PR DESCRIPTION
This fixes issues when setting the profile picture (wrong size was used for thumbnail), group changes by using the correct node name (participants) and group events normalization.