### PR TITLE
Use tmp instead of homegrown temp file creation.

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   "dependencies": {
     "gm": "^1.17.0",
     "jimp": "^0.2.1",
-    "mime": ">= 1.2.11"
+    "mime": ">= 1.2.11",
+    "tmp": ">= 0.0.26"
   },
   "devDependencies": {
     "jsdoc-to-markdown": "^0.6.4"


### PR DESCRIPTION
For discussion - puts files in a real temporary storage if they don't exist locally so they get cleaned up by the system rather than cluttering our home directory.

More ideas worth considering:
  - When creating a temporary file, add a flag somewhere to auto-delete after the send completes
  - Add a configuration option that says "the send callback should receive the media data" - this may be useful for accounting purposes (store everything sent in a database)

(#35)